### PR TITLE
Add radio player UI components

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,12 +1,11 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
 import { Platform } from 'react-native';
-
 import { HapticTab } from '@/components/HapticTab';
-import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { MaterialIcons } from '@expo/vector-icons';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
@@ -20,7 +19,6 @@ export default function TabLayout() {
         tabBarBackground: TabBarBackground,
         tabBarStyle: Platform.select({
           ios: {
-            // Use a transparent background on iOS to show the blur effect
             position: 'absolute',
           },
           default: {},
@@ -29,15 +27,37 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          title: 'Radio',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons name="radio" size={28} color={color} />
+          ),
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="news"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          title: 'Not\u00edcias',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons name="article" size={28} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="account"
+        options={{
+          title: 'Conta',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons name="person" size={28} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="config"
+        options={{
+          title: 'Config',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons name="settings" size={28} color={color} />
+          ),
         }}
       />
     </Tabs>

--- a/app/(tabs)/account.tsx
+++ b/app/(tabs)/account.tsx
@@ -1,0 +1,19 @@
+import { View, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function AccountScreen() {
+  return (
+    <View style={styles.container}>
+      <ThemedText>Account Screen</ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#081023',
+  },
+});

--- a/app/(tabs)/config.tsx
+++ b/app/(tabs)/config.tsx
@@ -1,0 +1,19 @@
+import { View, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function ConfigScreen() {
+  return (
+    <View style={styles.container}>
+      <ThemedText>Config Screen</ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#081023',
+  },
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,36 @@
-import FullScreenPlayer from '@/components/FullScreenPlayer';
+import { View, StyleSheet } from 'react-native';
+import TopBar from '@/components/TopBar';
+import RadioCard from '@/components/RadioCard';
+import PlaybackControls from '@/components/PlaybackControls';
+import BottomNavigation from '@/components/BottomNavigation';
+import { RADIO_STATION } from '@/utils/constants';
 
 export default function HomeScreen() {
-  return <FullScreenPlayer />;
+  return (
+    <View style={styles.container}>
+      <TopBar title="Top" subtitle="Playlist" avatarUrl={RADIO_STATION.logoUrl} />
+      <RadioCard
+        image={RADIO_STATION.logoUrl}
+        stationName="99.5 FM"
+        currentSong="O Sol - Vitor Klei"
+      />
+      <PlaybackControls />
+      <BottomNavigation
+        items={[
+          { icon: 'radio', label: 'Radio', active: true },
+          { icon: 'article', label: 'Not\u00edcias' },
+          { icon: 'person', label: 'Conta' },
+          { icon: 'settings', label: 'Config' },
+        ]}
+      />
+    </View>
+  );
 }
 
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#081023',
+    paddingTop: 40,
+  },
+});

--- a/app/(tabs)/news.tsx
+++ b/app/(tabs)/news.tsx
@@ -1,0 +1,19 @@
+import { View, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function NewsScreen() {
+  return (
+    <View style={styles.container}>
+      <ThemedText>News Screen</ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#081023',
+  },
+});

--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -1,0 +1,49 @@
+import { View, Pressable, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { ThemedText } from './ThemedText';
+
+export type NavItem = {
+  icon: React.ComponentProps<typeof MaterialIcons>['name'];
+  label: string;
+  active?: boolean;
+};
+
+export default function BottomNavigation({ items }: { items: NavItem[] }) {
+  return (
+    <View style={styles.container}>
+      {items.map((item) => (
+        <Pressable key={item.label} style={styles.item}>
+          <MaterialIcons
+            name={item.icon}
+            size={24}
+            color={item.active ? '#1F6AF0' : 'white'}
+          />
+          <ThemedText style={[styles.label, item.active && styles.activeLabel]}>
+            {item.label}
+          </ThemedText>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 8,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+  },
+  item: {
+    alignItems: 'center',
+    padding: 8,
+  },
+  label: {
+    fontSize: 12,
+    color: 'white',
+    marginTop: 4,
+  },
+  activeLabel: {
+    color: '#1F6AF0',
+  },
+});

--- a/components/PlaybackControls.tsx
+++ b/components/PlaybackControls.tsx
@@ -1,0 +1,30 @@
+import { View, Pressable, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import Player from './Player';
+
+export default function PlaybackControls() {
+  return (
+    <View style={styles.container}>
+      <Pressable style={styles.iconButton} onPress={() => {}}>
+        <MaterialIcons name="directions-car" size={28} color="white" />
+      </Pressable>
+      <Player />
+      <Pressable style={styles.iconButton} onPress={() => {}}>
+        <MaterialIcons name="favorite-border" size={28} color="white" />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    width: '100%',
+    paddingVertical: 16,
+  },
+  iconButton: {
+    padding: 8,
+  },
+});

--- a/components/RadioCard.tsx
+++ b/components/RadioCard.tsx
@@ -1,0 +1,47 @@
+import { Image } from 'expo-image';
+import { View, StyleSheet } from 'react-native';
+import { ThemedText } from './ThemedText';
+
+export default function RadioCard({
+  image,
+  stationName,
+  currentSong,
+}: {
+  image: string;
+  stationName: string;
+  currentSong: string;
+}) {
+  return (
+    <View style={styles.container}>
+      <Image source={{ uri: image }} style={styles.image} contentFit="cover" />
+      <ThemedText style={styles.station}>{stationName}</ThemedText>
+      <ThemedText style={styles.song}>{currentSong}</ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    marginVertical: 24,
+  },
+  image: {
+    width: 200,
+    height: 200,
+    borderRadius: 16,
+    marginBottom: 16,
+  },
+  station: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: 'white',
+    textAlign: 'center',
+  },
+  song: {
+    fontSize: 14,
+    color: 'white',
+    opacity: 0.8,
+    marginTop: 4,
+    textAlign: 'center',
+  },
+});

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,0 +1,53 @@
+import { Image, View, StyleSheet } from 'react-native';
+import { ThemedText } from './ThemedText';
+import { IconSymbol } from './ui/IconSymbol';
+
+export default function TopBar({
+  title,
+  subtitle,
+  avatarUrl,
+}: {
+  title: string;
+  subtitle?: string;
+  avatarUrl?: string;
+}) {
+  return (
+    <View style={styles.container}>
+      <IconSymbol name="chevron.right" size={24} color="white" />
+      <View style={styles.textContainer}>
+        <ThemedText style={styles.title}>{title}</ThemedText>
+        {subtitle && <ThemedText style={styles.subtitle}>{subtitle}</ThemedText>}
+      </View>
+      {avatarUrl && <Image source={{ uri: avatarUrl }} style={styles.avatar} />}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  textContainer: {
+    flex: 1,
+    marginLeft: 8,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: 'white',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: 'white',
+    opacity: 0.8,
+  },
+  avatar: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- implement TopBar, RadioCard, PlaybackControls and BottomNavigation components
- redesign home screen with new components
- add placeholder News, Account and Config screens
- expand tab layout to four tabs using MaterialIcons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a5d2f2da88332b6dc469aaee359ab