### PR TITLE
Implement dark themed player screen

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,31 +1,5 @@
-import { View, StyleSheet } from 'react-native';
-import TopBar from '@/components/TopBar';
-import RadioCard from '@/components/RadioCard';
-import PlaybackControls from '@/components/PlaybackControls';
-import AnimatedBackground from '@/components/AnimatedBackground';
-import { RADIO_STATION } from '@/utils/constants';
-import { Spacing } from '@/constants/GeologicaUIKit';
+import FullScreenPlayer from '@/components/FullScreenPlayer';
 
 export default function HomeScreen() {
-  return (
-    <AnimatedBackground>
-      <View style={styles.container}>
-        <TopBar title="Top" subtitle="Playlist" avatarUrl={RADIO_STATION.logoUrl} />
-        <RadioCard
-          image={RADIO_STATION.logoUrl}
-          stationName="99.5 FM"
-          currentSong="O Sol - Vitor Klei"
-        />
-        <PlaybackControls />
-      </View>
-    </AnimatedBackground>
-  );
+  return <FullScreenPlayer />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: 'transparent',
-    paddingTop: Spacing.xl,
-  },
-});

--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -1,7 +1,13 @@
 import { View, Pressable, StyleSheet } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { ThemedText } from './ThemedText';
-import { Colors, Spacing, Typography } from '@/constants/GeologicaUIKit';
+import {
+  Colors,
+  ComponentStyles,
+  DarkModeStyles,
+  Typography,
+  Spacing,
+} from '@/constants/GeologicaUIKit';
 
 export type NavItem = {
   icon: React.ComponentProps<typeof MaterialIcons>['name'];
@@ -11,15 +17,21 @@ export type NavItem = {
 
 export default function BottomNavigation({ items }: { items: NavItem[] }) {
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, ComponentStyles.tabBar, DarkModeStyles.tabBar]}>
       {items.map((item) => (
-        <Pressable key={item.label} style={styles.item}>
+        <Pressable key={item.label} style={ComponentStyles.tabItem}>
           <MaterialIcons
             name={item.icon}
             size={24}
-            color={item.active ? Colors.light.primary : Colors.dark.white}
+            color={item.active ? Colors.dark.primary : Colors.dark.textSecondary}
           />
-          <ThemedText style={[styles.label, item.active && styles.activeLabel]}>
+          <ThemedText
+            style={[
+              styles.label,
+              DarkModeStyles.tabLabel,
+              item.active && DarkModeStyles.tabLabelActive,
+            ]}
+          >
             {item.label}
           </ThemedText>
         </Pressable>
@@ -29,22 +41,11 @@ export default function BottomNavigation({ items }: { items: NavItem[] }) {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    paddingVertical: Spacing.sm,
-    backgroundColor: Colors.dark.secondary,
-  },
-  item: {
-    alignItems: 'center',
-    padding: Spacing.sm,
-  },
+  container: {},
   label: {
+    fontFamily: Typography.fontFamily,
     fontSize: Typography.sizes.xs,
-    color: Colors.dark.white,
+    color: Colors.dark.textSecondary,
     marginTop: Spacing.xs,
-  },
-  activeLabel: {
-    color: Colors.light.primary,
   },
 });

--- a/components/FullScreenPlayer.tsx
+++ b/components/FullScreenPlayer.tsx
@@ -1,40 +1,176 @@
-import { Image } from 'expo-image';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
-
-import AnimatedBackground from './AnimatedBackground';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+} from 'react-native';
+import Animated, { useSharedValue, withTiming, useAnimatedStyle } from 'react-native-reanimated';
+import { MaterialIcons } from '@expo/vector-icons';
 import Player from './Player';
-import { ThemedText } from './ThemedText';
-import { RADIO_STATION } from '@/utils/constants';
+import BottomNavigation from './BottomNavigation';
+import {
+  Colors,
+  Typography,
+  Spacing,
+  ComponentStyles,
+  BorderRadius,
+  DarkModeStyles,
+} from '@/constants/GeologicaUIKit';
 
 export default function FullScreenPlayer() {
+  const leftScale = useSharedValue(1);
+  const rightScale = useSharedValue(1);
+
+  const leftStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: leftScale.value }],
+  }));
+
+  const rightStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: rightScale.value }],
+  }));
+
   return (
-    <AnimatedBackground>
-      <View style={styles.content}>
-        <Image source={{ uri: RADIO_STATION.logoUrl }} style={styles.logo} />
-        <ThemedText type="title" style={styles.title}>
-          {RADIO_STATION.name}
-        </ThemedText>
-        <Player />
+    <SafeAreaView style={[styles.container, ComponentStyles.darkContainer]}>
+      <View style={styles.header}>
+        <Pressable style={styles.headerButton}>
+          <MaterialIcons name="arrow-back" size={24} color={Colors.dark.white} />
+        </Pressable>
+        <Text style={styles.headerTitle}>Top Playlist</Text>
+        <Pressable style={styles.headerButton}>
+          <MaterialIcons name="person" size={24} color={Colors.dark.white} />
+        </Pressable>
       </View>
-    </AnimatedBackground>
+
+      <View style={styles.card}>
+        <Text style={styles.cardText}>99.5 FM</Text>
+      </View>
+
+      <View style={styles.trackInfo}>
+        <Text style={styles.songTitle}>Rádio Muriaé</Text>
+        <Text style={styles.station}>99.5 FM</Text>
+      </View>
+
+      <View style={styles.controls}>
+        <Pressable
+          onPressIn={() => (leftScale.value = withTiming(0.9))}
+          onPressOut={() => (leftScale.value = withTiming(1))}
+          style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}
+        >
+          <Animated.View style={leftStyle}>
+            <MaterialIcons name="directions-car" size={32} color={Colors.dark.white} />
+          </Animated.View>
+        </Pressable>
+
+        <Player buttonSize={48} iconSize={32} />
+
+        <Pressable
+          onPressIn={() => (rightScale.value = withTiming(0.9))}
+          onPressOut={() => (rightScale.value = withTiming(1))}
+          style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}
+        >
+          <Animated.View style={rightStyle}>
+            <MaterialIcons name="favorite-border" size={32} color={Colors.dark.white} />
+          </Animated.View>
+        </Pressable>
+      </View>
+
+      <View style={styles.extraControls}>
+        <Pressable style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}>
+          <MaterialIcons name="cast" size={24} color={Colors.dark.white} />
+        </Pressable>
+        <Pressable style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}>
+          <MaterialIcons name="more-horiz" size={24} color={Colors.dark.white} />
+        </Pressable>
+      </View>
+
+      <BottomNavigation
+        items={[
+          { icon: 'radio', label: 'Radio', active: true },
+          { icon: 'explore', label: 'Discover' },
+          { icon: 'library-music', label: 'Library' },
+          { icon: 'settings', label: 'Settings' },
+        ]}
+      />
+    </SafeAreaView>
   );
 }
 
+const CARD_SIZE = 280;
+
 const styles = StyleSheet.create({
-  content: {
+  container: {
     flex: 1,
+    backgroundColor: Colors.dark.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+  },
+  headerTitle: {
+    fontFamily: Typography.fontFamily,
+    fontSize: Typography.sizes.lg,
+    fontWeight: Typography.fontWeights.semibold as any,
+    color: Colors.dark.white,
+  },
+  headerButton: {
+    padding: Spacing.sm,
+  },
+  card: {
+    ...ComponentStyles.card,
+    ...DarkModeStyles.darkCard,
+    width: CARD_SIZE,
+    height: CARD_SIZE,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: '#dc2626',
+    alignSelf: 'center',
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 32,
+    marginVertical: Spacing.xl,
   },
-  logo: {
-    width: 200,
-    height: 200,
-    marginBottom: 24,
+  cardText: {
+    fontFamily: Typography.fontFamily,
+    fontSize: Typography.sizes.xxl,
+    fontWeight: Typography.fontWeights.bold as any,
+    color: Colors.dark.white,
   },
-  title: {
-    marginBottom: 16,
-    textAlign: 'center',
+  trackInfo: {
+    alignItems: 'center',
+    marginBottom: Spacing.xl,
+  },
+  songTitle: {
+    fontFamily: Typography.fontFamily,
+    fontSize: Typography.sizes.lg,
+    fontWeight: Typography.fontWeights.semibold as any,
+    color: Colors.dark.text,
+  },
+  station: {
+    fontFamily: Typography.fontFamily,
+    fontSize: Typography.sizes.sm,
+    color: Colors.dark.textSecondary,
+    opacity: 0.7,
+    marginTop: Spacing.xs,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    paddingHorizontal: Spacing.xl,
+    marginBottom: Spacing.lg,
+  },
+  iconButton: {
+    padding: Spacing.sm,
+  },
+  iconPressed: {
+    opacity: 0.7,
+  },
+  extraControls: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginBottom: Spacing.lg,
   },
 });

--- a/components/Player.tsx
+++ b/components/Player.tsx
@@ -5,8 +5,19 @@ import { MaterialIcons } from '@expo/vector-icons';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import { STREAM_URL } from '@/utils/constants';
+import {
+  Colors,
+  ComponentStyles,
+  DarkModeStyles,
+  BorderRadius,
+} from '@/constants/GeologicaUIKit';
 
-export default function Player() {
+export type PlayerProps = {
+  buttonSize?: number;
+  iconSize?: number;
+};
+
+export default function Player({ buttonSize = 100, iconSize = 64 }: PlayerProps) {
   const [sound, setSound] = useState<Audio.Sound | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const scale = useSharedValue(1);
@@ -55,12 +66,23 @@ export default function Player() {
           scale.value = withTiming(1);
         }}
         onPress={togglePlayback}
-        style={styles.pressable}>
-        <Animated.View style={[styles.button, animatedStyle]}>
+        style={({ pressed }) => [styles.pressable, pressed && styles.pressed]}
+      >
+        <Animated.View
+          style={[
+            styles.button,
+            {
+              height: buttonSize,
+              width: buttonSize,
+              borderRadius: buttonSize / 2,
+            },
+            animatedStyle,
+          ]}
+        >
           <MaterialIcons
             name={isPlaying ? 'pause' : 'play-arrow'}
-            size={64}
-            color="white"
+            size={iconSize}
+            color={Colors.dark.white}
           />
         </Animated.View>
       </Pressable>
@@ -74,14 +96,16 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   pressable: {
-    borderRadius: 50,
+    borderRadius: BorderRadius.full,
   },
   button: {
-    height: 100,
-    width: 100,
-    borderRadius: 50,
-    backgroundColor: '#0a7ea4',
+    ...ComponentStyles.primaryButton,
+    ...DarkModeStyles.primaryButton,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  pressed: {
+    ...ComponentStyles.primaryButtonPressed,
+    ...DarkModeStyles.primaryButton,
   },
 });


### PR DESCRIPTION
## Summary
- redesign player UI with dark GeologicaUIKit styling
- update Player component to support custom sizes and pressed style
- apply GeologicaUIKit tab bar styles
- simplify radio tab to show FullScreenPlayer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a640630648332af671f8797488a71