### PR TITLE
Fix play button icon

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
+import { MaterialIcons } from '@expo/vector-icons';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
@@ -10,6 +11,7 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+    ...MaterialIcons.font,
   });
 
   if (!loaded) {


### PR DESCRIPTION
## Summary
- load MaterialIcons font in RootLayout to ensure icons display

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a688028b88332aa29aab9835bcb76