### PR TITLE
Fix player icons on iOS

### DIFF
--- a/components/Player.tsx
+++ b/components/Player.tsx
@@ -1,4 +1,4 @@
-import { MaterialIcons } from "@expo/vector-icons";
+import { IconSymbol } from "@/components/ui/IconSymbol";
 import { Audio } from "expo-av";
 import React, { useEffect, useState } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, View } from "react-native";
@@ -29,12 +29,6 @@ export default function Player({
   const [isPlaying, setIsPlaying] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const scale = useSharedValue(1);
-
-  useEffect(() => {
-    // Ensure MaterialIcons font is loaded in case the root layout did not load it
-    MaterialIcons.loadFont();
-  }, []);
-
   useEffect(() => {
     Audio.setAudioModeAsync({
       staysActiveInBackground: true,
@@ -117,8 +111,8 @@ export default function Player({
           {isLoading ? (
             <ActivityIndicator color={Colors.dark.white} size="large" />
           ) : (
-            <MaterialIcons
-              name={isPlaying ? "pause" : "play-arrow"}
+            <IconSymbol
+              name={isPlaying ? 'pause.fill' : 'play.fill'}
               size={iconSize}
               color={Colors.dark.white}
             />

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,8 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'play.fill': 'play-arrow',
+  'pause.fill': 'pause',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- map play and pause symbols to Material icons
- use IconSymbol in Player so iOS uses SF Symbols

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a6e8b285c833290efd7788f0e2e2d