### PR TITLE
Integrate explore content into other tabs

### DIFF
--- a/app/(tabs)/account.tsx
+++ b/app/(tabs)/account.tsx
@@ -1,19 +1,5 @@
-import { View, StyleSheet } from 'react-native';
-import { ThemedText } from '@/components/ThemedText';
+import ExampleContent from '@/components/ExampleContent';
 
 export default function AccountScreen() {
-  return (
-    <View style={styles.container}>
-      <ThemedText>Account Screen</ThemedText>
-    </View>
-  );
+  return <ExampleContent title="Conta" />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#081023',
-  },
-});

--- a/app/(tabs)/config.tsx
+++ b/app/(tabs)/config.tsx
@@ -1,19 +1,5 @@
-import { View, StyleSheet } from 'react-native';
-import { ThemedText } from '@/components/ThemedText';
+import ExampleContent from '@/components/ExampleContent';
 
 export default function ConfigScreen() {
-  return (
-    <View style={styles.container}>
-      <ThemedText>Config Screen</ThemedText>
-    </View>
-  );
+  return <ExampleContent title="Config" />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#081023',
-  },
-});

--- a/app/(tabs)/news.tsx
+++ b/app/(tabs)/news.tsx
@@ -1,19 +1,5 @@
-import { View, StyleSheet } from 'react-native';
-import { ThemedText } from '@/components/ThemedText';
+import ExampleContent from '@/components/ExampleContent';
 
 export default function NewsScreen() {
-  return (
-    <View style={styles.container}>
-      <ThemedText>News Screen</ThemedText>
-    </View>
-  );
+  return <ExampleContent title="Notícias" />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#081023',
-  },
-});

--- a/components/ExampleContent.tsx
+++ b/components/ExampleContent.tsx
@@ -8,7 +8,7 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 
-export default function TabTwoScreen() {
+export default function ExampleContent({ title = 'Explore' }: { title?: string }) {
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
@@ -21,14 +21,16 @@ export default function TabTwoScreen() {
         />
       }>
       <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Explore</ThemedText>
+        <ThemedText type="title">{title}</ThemedText>
       </ThemedView>
       <ThemedText>This app includes example code to help you get started.</ThemedText>
       <Collapsible title="File-based routing">
         <ThemedText>
-          This app has two screens:{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/explore.tsx</ThemedText>
+          This app has multiple screens such as{' '}
+          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText>,{' '}
+          <ThemedText type="defaultSemiBold">app/(tabs)/news.tsx</ThemedText>,{' '}
+          <ThemedText type="defaultSemiBold">app/(tabs)/account.tsx</ThemedText>, and{' '}
+          <ThemedText type="defaultSemiBold">app/(tabs)/config.tsx</ThemedText>.
         </ThemedText>
         <ThemedText>
           The layout file in <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}


### PR DESCRIPTION
## Summary
- remove the old explore page
- create `ExampleContent` component with the previous explore layout
- reuse the new component on `Notícias`, `Conta`, and `Config` screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b51dcb7e48332a78500a1761ebe9a