### PR TITLE
Implement placeholder screencast handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Screencast
+
+The cast button in the full screen player currently logs a screencast request. Integrate a proper casting solution in `services/screencast.js`.

--- a/components/FullScreenPlayer.tsx
+++ b/components/FullScreenPlayer.tsx
@@ -17,6 +17,8 @@ import {
 } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import Player from './Player';
+import { startScreencast } from '@/services/screencast';
+import { STREAM_URL } from '@/utils/constants';
 
 export default function FullScreenPlayer() {
   const leftScale = useSharedValue(1);
@@ -76,7 +78,10 @@ export default function FullScreenPlayer() {
       </View>
 
       <View style={styles.extraControls}>
-        <Pressable style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}>
+        <Pressable
+          onPress={() => startScreencast(STREAM_URL)}
+          style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}
+        >
           <MaterialIcons name="cast" size={24} color={Colors.dark.white} />
         </Pressable>
         <Pressable style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}>

--- a/services/screencast.js
+++ b/services/screencast.js
@@ -1,0 +1,6 @@
+export async function startScreencast(streamUrl) {
+  console.log('Screencast requested for', streamUrl);
+  // TODO: integrate react-native-google-cast or other screencast library.
+  // This is a placeholder implementation because the actual
+  // native module cannot be installed in this environment.
+}


### PR DESCRIPTION
## Summary
- add placeholder service to handle screencast button
- wire screencast button to the new service
- mention screencast placeholder in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b5361b95c8332bf01212546e48b56