### PR TITLE
Add Google Cast support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,7 @@ Join our community of developers creating universal apps.
 
 ## Screencast
 
-The cast button in the full screen player currently logs a screencast request. Integrate a proper casting solution in `services/screencast.js`.
+This project integrates with **react-native-google-cast**. Install the library
+and run the app on a device with Cast support to stream the radio to an external
+receiver. If the native module is missing, the cast button will gracefully
+fallback to a no-op implementation.

--- a/components/CastButton.tsx
+++ b/components/CastButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Pressable, StyleProp, ViewStyle } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+
+let GoogleCast: any;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  GoogleCast = require('react-native-google-cast');
+} catch {
+  GoogleCast = null;
+}
+
+export type CastButtonProps = {
+  color?: string;
+  size?: number;
+  style?: StyleProp<ViewStyle>;
+  onPress?: () => void;
+};
+
+/**
+ * Display the native Google Cast button when the library is installed. Falls
+ * back to a simple icon that triggers the provided `onPress` handler otherwise.
+ */
+export default function CastButton({
+  color = 'white',
+  size = 24,
+  style,
+  onPress,
+}: CastButtonProps) {
+  if (GoogleCast?.CastButton) {
+    return <GoogleCast.CastButton style={style} tintColor={color} />;
+  }
+  return (
+    <Pressable onPress={onPress} style={style}>
+      <MaterialIcons name="cast" size={size} color={color} />
+    </Pressable>
+  );
+}

--- a/components/FullScreenPlayer.tsx
+++ b/components/FullScreenPlayer.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import Player from './Player';
+import CastButton from './CastButton';
 import { startScreencast } from '@/services/screencast';
 import { STREAM_URL } from '@/utils/constants';
 
@@ -78,12 +79,10 @@ export default function FullScreenPlayer() {
       </View>
 
       <View style={styles.extraControls}>
-        <Pressable
+        <CastButton
           onPress={() => startScreencast(STREAM_URL)}
-          style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}
-        >
-          <MaterialIcons name="cast" size={24} color={Colors.dark.white} />
-        </Pressable>
+          style={styles.iconButton}
+        />
         <Pressable style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}>
           <MaterialIcons name="more-horiz" size={24} color={Colors.dark.white} />
         </Pressable>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "react-native-google-cast": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/screencast.js
+++ b/services/screencast.js
@@ -1,6 +1,53 @@
+let GoogleCast;
+try {
+  // Dynamically require so the app still bundles without the native module
+  GoogleCast = require('react-native-google-cast');
+} catch (e) {
+  GoogleCast = null;
+}
+
+/**
+ * Start casting the provided audio stream using react-native-google-cast when
+ * available. If the library is not installed, the request is logged so the app
+ * can continue to run without crashing.
+ */
 export async function startScreencast(streamUrl) {
-  console.log('Screencast requested for', streamUrl);
-  // TODO: integrate react-native-google-cast or other screencast library.
-  // This is a placeholder implementation because the actual
-  // native module cannot be installed in this environment.
+  if (!GoogleCast) {
+    console.log('Screencast requested for', streamUrl);
+    return;
+  }
+
+  try {
+    // Show the device picker so the user can choose where to cast
+    if (GoogleCast.showCastPicker) {
+      await GoogleCast.showCastPicker();
+    }
+
+    const client =
+      GoogleCast.getCastContext?.()
+        ?.getSessionManager?.()
+        ?.getCurrentSession?.()
+        ?.getRemoteMediaClient?.();
+
+    if (client?.loadMedia) {
+      await client.loadMedia({
+        mediaInfo: {
+          contentUrl: streamUrl,
+          contentType: 'audio/mpeg',
+          streamType: 'LIVE',
+          metadata: { mediaType: GoogleCast.MediaTypes.AUDIO },
+        },
+      });
+    } else if (GoogleCast.castMedia) {
+      // Fallback for older versions of the library
+      await GoogleCast.castMedia({
+        mediaUrl: streamUrl,
+        title: 'Radio Stream',
+        contentType: 'audio/mpeg',
+        streamType: 'LIVE',
+      });
+    }
+  } catch (err) {
+    console.warn('Failed to start screencast', err);
+  }
 }


### PR DESCRIPTION
## Summary
- integrate `react-native-google-cast` as a dependency
- implement screencast service using Google Cast when available
- add a `CastButton` component that uses the native cast button if the module exists
- update full screen player to use `CastButton`
- document casting in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b54d338f88332a9e2b4ac94087f1d