### PR TITLE
Add AirPlay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,8 @@ This project integrates with **react-native-google-cast**. Install the library
 and run the app on a device with Cast support to stream the radio to an external
 receiver. If the native module is missing, the cast button will gracefully
 fallback to a no-op implementation.
+
+The full screen player also exposes an **AirPlay** button powered by
+`react-native-airplay-btn`. On iOS devices this opens the system route picker so
+you can stream audio to Apple TVs or other AirPlay receivers. If the native
+module is unavailable, the button simply renders an icon.

--- a/components/AirPlayButton.tsx
+++ b/components/AirPlayButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Pressable, StyleProp, ViewStyle } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+
+let AirPlay: any;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  AirPlay = require('react-native-airplay-btn');
+} catch {
+  AirPlay = null;
+}
+
+export type AirPlayButtonProps = {
+  color?: string;
+  size?: number;
+  style?: StyleProp<ViewStyle>;
+  onPress?: () => void;
+};
+
+/**
+ * Display the native AirPlay button when the library is installed. Falls
+ * back to a simple icon that triggers the provided `onPress` handler otherwise.
+ */
+export default function AirPlayButton({
+  color = 'white',
+  size = 24,
+  style,
+  onPress,
+}: AirPlayButtonProps) {
+  if (AirPlay?.RoutePickerView) {
+    return <AirPlay.RoutePickerView style={style} tintColor={color} />;
+  }
+  return (
+    <Pressable onPress={onPress} style={style}>
+      <MaterialIcons name="airplay" size={size} color={color} />
+    </Pressable>
+  );
+}

--- a/components/FullScreenPlayer.tsx
+++ b/components/FullScreenPlayer.tsx
@@ -18,6 +18,7 @@ import {
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import Player from './Player';
 import CastButton from './CastButton';
+import AirPlayButton from './AirPlayButton';
 import { startScreencast } from '@/services/screencast';
 import { STREAM_URL } from '@/utils/constants';
 
@@ -83,6 +84,7 @@ export default function FullScreenPlayer() {
           onPress={() => startScreencast(STREAM_URL)}
           style={styles.iconButton}
         />
+        <AirPlayButton style={styles.iconButton} />
         <Pressable style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}>
           <MaterialIcons name="more-horiz" size={24} color={Colors.dark.white} />
         </Pressable>


### PR DESCRIPTION
## Summary
- add `AirPlayButton` component that uses `react-native-airplay-btn` when available
- expose AirPlay button on the full screen player
- document AirPlay support in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b57823a588332a66697dc67d1cc90