### PR TITLE
Add AirPlay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Join our community of developers creating universal apps.
 
 ## Screencast
 
-This project integrates with **react-native-google-cast**. Install the library
-and run the app on a device with Cast support to stream the radio to an external
-receiver. If the native module is missing, the cast button will gracefully
-fallback to a no-op implementation.
+This project integrates with **react-native-google-cast** and **react-native-airplay-btn**.
+Install these libraries and run the app on a device with Cast or AirPlay support
+to stream the radio to an external receiver or AirPlay device. If either native
+module is missing, the corresponding button will gracefully fallback to a no-op
+implementation.

--- a/components/AirPlayButton.tsx
+++ b/components/AirPlayButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Pressable, StyleProp, ViewStyle } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { startAirPlay } from '@/services/airplay';
+
+let AirPlay: any;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  AirPlay = require('react-native-airplay-btn');
+} catch {
+  AirPlay = null;
+}
+
+export type AirPlayButtonProps = {
+  color?: string;
+  size?: number;
+  style?: StyleProp<ViewStyle>;
+  onPress?: () => void;
+};
+
+/**
+ * Display the native AirPlay button when the library is installed. Falls back
+ * to a simple icon that triggers the provided `onPress` handler otherwise.
+ */
+export default function AirPlayButton({
+  color = 'white',
+  size = 24,
+  style,
+  onPress,
+}: AirPlayButtonProps) {
+  if (AirPlay?.AirPlayButton) {
+    return <AirPlay.AirPlayButton style={style} activeTintColor={color} />;
+  }
+  return (
+    <Pressable onPress={onPress ?? startAirPlay} style={style}>
+      <MaterialIcons name="airplay" size={size} color={color} />
+    </Pressable>
+  );
+}

--- a/components/FullScreenPlayer.tsx
+++ b/components/FullScreenPlayer.tsx
@@ -18,7 +18,9 @@ import {
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import Player from './Player';
 import CastButton from './CastButton';
+import AirPlayButton from './AirPlayButton';
 import { startScreencast } from '@/services/screencast';
+import { startAirPlay } from '@/services/airplay';
 import { STREAM_URL } from '@/utils/constants';
 
 export default function FullScreenPlayer() {
@@ -83,6 +85,7 @@ export default function FullScreenPlayer() {
           onPress={() => startScreencast(STREAM_URL)}
           style={styles.iconButton}
         />
+        <AirPlayButton onPress={startAirPlay} style={styles.iconButton} />
         <Pressable style={({ pressed }) => [styles.iconButton, pressed && styles.iconPressed]}>
           <MaterialIcons name="more-horiz" size={24} color={Colors.dark.white} />
         </Pressable>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "react-native-google-cast": "^5.0.0"
+    "react-native-google-cast": "^5.0.0",
+    "react-native-airplay-btn": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/airplay.js
+++ b/services/airplay.js
@@ -1,0 +1,26 @@
+let AirPlay;
+try {
+  // Dynamically require so the app still bundles without the native module
+  AirPlay = require('react-native-airplay-btn');
+} catch (e) {
+  AirPlay = null;
+}
+
+/**
+ * Attempt to show the AirPlay route picker. If the library is not installed,
+ * the request is logged so the app can continue to run without crashing.
+ */
+export async function startAirPlay() {
+  if (!AirPlay) {
+    console.log('AirPlay requested');
+    return;
+  }
+
+  try {
+    if (AirPlay.showRoutePicker) {
+      await AirPlay.showRoutePicker();
+    }
+  } catch (err) {
+    console.warn('Failed to start AirPlay', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add new AirPlayButton component
- create service helper to invoke AirPlay picker
- integrate AirPlay button into `FullScreenPlayer`
- document the new feature in the README
- add `react-native-airplay-btn` dependency

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b57823a588332a66697dc67d1cc90