### PR TITLE
Add basic car display integration

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -34,6 +34,15 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="car"
+        options={{
+          title: 'Car',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons name="directions-car" size={28} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="news"
         options={{
           title: 'Not\u00edcias',

--- a/app/(tabs)/car.tsx
+++ b/app/(tabs)/car.tsx
@@ -1,0 +1,5 @@
+import CarDisplay from '@/components/CarDisplay';
+
+export default function CarScreen() {
+  return <CarDisplay />;
+}

--- a/components/CarDisplay.tsx
+++ b/components/CarDisplay.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from 'react';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import Player from './Player';
+import {
+  Colors,
+  Typography,
+  Spacing,
+} from '@/constants/GeologicaUIKit';
+import { startCarPlay, startAndroidAuto } from '@/services/carIntegration';
+
+export default function CarDisplay() {
+  useEffect(() => {
+    startCarPlay();
+    startAndroidAuto();
+  }, []);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Car Display</Text>
+      <View style={styles.playerContainer}>
+        <Player buttonSize={120} iconSize={64} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.dark.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontFamily: Typography.fontFamily,
+    fontSize: Typography.sizes.xxxl,
+    color: Colors.dark.text,
+    marginBottom: Spacing.lg,
+  },
+  playerContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/services/carIntegration.js
+++ b/services/carIntegration.js
@@ -1,0 +1,51 @@
+let CarPlay;
+try {
+  CarPlay = require('react-native-carplay');
+} catch (e) {
+  CarPlay = null;
+}
+
+let AndroidAuto;
+try {
+  AndroidAuto = require('react-native-android-auto');
+} catch (e) {
+  AndroidAuto = null;
+}
+
+/**
+ * Start CarPlay integration when available. Logs a request when the
+ * native module is missing so the app can continue to run.
+ */
+export async function startCarPlay() {
+  if (!CarPlay) {
+    console.log('CarPlay integration requested');
+    return;
+  }
+
+  try {
+    if (CarPlay.register) {
+      await CarPlay.register();
+    }
+  } catch (err) {
+    console.warn('Failed to start CarPlay', err);
+  }
+}
+
+/**
+ * Start Android Auto integration when available. Logs a request when the
+ * native module is missing so the app can continue to run.
+ */
+export async function startAndroidAuto() {
+  if (!AndroidAuto) {
+    console.log('Android Auto integration requested');
+    return;
+  }
+
+  try {
+    if (AndroidAuto.initialize) {
+      await AndroidAuto.initialize();
+    }
+  } catch (err) {
+    console.warn('Failed to start Android Auto', err);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce placeholder car integration services
- add CarDisplay component to provide simple car UI
- include new car tab screen

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b593f93408332b5086afa128858a7